### PR TITLE
add landing page for application

### DIFF
--- a/inst/shiny/app/app.R
+++ b/inst/shiny/app/app.R
@@ -37,6 +37,10 @@ adlb <- haven::read_xpt(file.path(path$adam, "adlbc.xpt")) %>%
 ui <- fluidPage(
   tabsetPanel(
     tabPanel(
+      "Introduction",
+      shiny::includeMarkdown("include/about.md")
+    ),
+    tabPanel(
       "Demographic Table", 
       uiOutput("tbl_demog")
     ),

--- a/inst/shiny/app/include/about.md
+++ b/inst/shiny/app/include/about.md
@@ -1,1 +1,19 @@
-> Placeholder text written in Markdown.
+## Introduction
+
+This application is intended for a pilot submission to the FDA composing of a Shiny application, as part of the [R Submissions Working Group](https://rconsortium.github.io/submissions-wg/) Pilot 2. The data sets and results displayed in the application originate from the [Pilot 1 project](https://rconsortium.github.io/submissions-wg/pilot-overall.html#pilot-1---common-analyses). Below is a brief description of the rest of the application:
+
+### Demographic Table
+
+In this interface, summary statistics associated with baseline clinical characteristics and other demographic factors is shown.
+
+### KM-Plot for TTDE
+
+A Kaplan-Meier (KM) plot of the Time to First Dermatologic Event (TTDE) with strata defined by treatment group is displayed along with an informative risk set table across time.
+
+### Primary Table
+
+A summary table of the primary efficacy analysis is shown for each of the time points of assessment (baseline and week 24) comparing each treatment group. The pimary efficacy variable was analyzed using an Analysis of Covariance (ANCOVA) model with treatment and baseline value as covariates, comparing Placebo to Xanomeline High Dose.
+
+### Efficacy Table
+
+TODO: Finish


### PR DESCRIPTION
This PR adds a simple introduction landing page to the overall application. The functionality is straight-forward thanks to the `shiny::includeMarkdown()` function. The text itself can be tweaked very easily. 